### PR TITLE
Update SSH deploy key and workflows

### DIFF
--- a/.github/workflows/auto-pr.yaml
+++ b/.github/workflows/auto-pr.yaml
@@ -5,9 +5,8 @@ on:
     branches-ignore:
       - main
       - master
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
-    
+
 jobs:
   create-pr:
     runs-on: ubuntu-latest
@@ -21,21 +20,22 @@ jobs:
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
           git config --global init.defaultBranch main
 
-      - name: Create or update draft PR
+      - name: Generate PR title and body using GitHub Copilot
+        id: copilot_pr
+        run: |
+          echo "title=$(copilot-pr-title)" >> $GITHUB_ENV
+          echo "body=$(copilot-pr-body)" >> $GITHUB_ENV
+
+      - name: Create or update PR
         id: create_pr
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: 'chore: update draft PR'
+          commit-message: 'chore: update PR'
           branch: ${{ github.ref }}
-          title: ${{ github.event.head_commit.message }}
-          body: |
-            This PR was automatically created by GitHub Actions.
-            - Commit: ${{ github.sha }}
-            - Author: ${{ github.actor }}
-            - Date: ${{ github.event.head_commit.timestamp }}
+          title: ${{ env.title }}
+          body: ${{ env.body }}
           draft: false
-
 
   update-release-notes:
     runs-on: ubuntu-latest
@@ -51,14 +51,9 @@ jobs:
           config-name: .github/workflows/release_configuration_complex.json
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Update draft release notes
-        run: |
-          gh release create draft --notes "${{ steps.release_notes.outputs.notes }}" --target ${{ github.ref }}
-
   run-tests:
     needs: [create-pr, update-release-notes]
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false && success()
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/auto-pr.yaml
+++ b/.github/workflows/auto-pr.yaml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     
 jobs:
-  create-draft-pr:
+  create-pr:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -28,13 +28,18 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: 'chore: update draft PR'
           branch: ${{ github.ref }}
-          title: 'Draft PR for ${{ github.ref }}'
-          body: 'This is a draft PR for the branch ${{ github.ref }}. It will be updated with each push to this branch.'
-          draft: true
+          title: ${{ github.event.head_commit.message }}
+          body: |
+            This PR was automatically created by GitHub Actions.
+            - Commit: ${{ github.sha }}
+            - Author: ${{ github.actor }}
+            - Date: ${{ github.event.head_commit.timestamp }}
+          draft: false
+
 
   update-release-notes:
     runs-on: ubuntu-latest
-    needs: create-draft-pr
+    needs: create-pr
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -44,14 +49,16 @@ jobs:
         uses: release-drafter/release-drafter@v5
         with:
           config-name: .github/workflows/release_configuration_complex.json
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update draft release notes
         run: |
           gh release create draft --notes "${{ steps.release_notes.outputs.notes }}" --target ${{ github.ref }}
 
   run-tests:
+    needs: [create-pr, update-release-notes]
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false && success()
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -70,14 +77,3 @@ jobs:
         run: |
           pytest
 
-  merge-pr:
-    runs-on: ubuntu-latest
-    needs: run-tests
-    if: github.event.pull_request.draft == false && success()
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Merge PR
-        run: |
-          gh pr merge ${{ github.event.pull_request.number }} --merge

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -62,7 +62,7 @@ jobs:
       - name: Set up SSH
         uses: webfactory/ssh-agent@v0.5.3
         with:
-          ssh-private-key: ${{ secrets.SSH_DEPLOY_KEY }}
+          ssh-private-key: ${{ secrets.KLINGON_TOOLS_DEPLOY_KEY }}
 
       # Get PyPI Test Version Number
       - name: Get PyPI Test Version Number
@@ -164,7 +164,7 @@ jobs:
       - name: Set up SSH
         uses: webfactory/ssh-agent@v0.5.3
         with:
-          ssh-private-key: ${{ secrets.SSH_DEPLOY_KEY }}
+          ssh-private-key: ${{ secrets.KLINGON_TOOLS_DEPLOY_KEY }}
 
       # Echo the new version number
       - name: Echo the version number
@@ -251,7 +251,7 @@ jobs:
       - name: Set up SSH
         uses: webfactory/ssh-agent@v0.5.3
         with:
-          ssh-private-key: ${{ secrets.SSH_DEPLOY_KEY }}
+          ssh-private-key: ${{ secrets.KLINGON_TOOLS_DEPLOY_KEY }}
 
       # Echo the new version number
       - name: Echo the version number
@@ -320,7 +320,7 @@ jobs:
       - name: Set up SSH
         uses: webfactory/ssh-agent@v0.5.3
         with:
-          ssh-private-key: ${{ secrets.SSH_DEPLOY_KEY }}
+          ssh-private-key: ${{ secrets.KLINGON_TOOLS_DEPLOY_KEY }}
 
       # Echo the new version number
       - name: Echo the version number

--- a/.github/workflows/release_configuration_complex.json
+++ b/.github/workflows/release_configuration_complex.json
@@ -78,5 +78,5 @@
       "flags": "gu"
     }
   },
-  "base_branches": ["dev"]
+  "base_branches": ["main"]
 }


### PR DESCRIPTION
This pull request updates the SSH deploy key used in the GitHub Actions workflow to use the `KLINGON_TOOLS_DEPLOY_KEY` secret instead of `SSH_DEPLOY_KEY`. It also updates the auto PR workflow to create a pull request instead of a draft pull request. Additionally, the base branches in the release configuration file are updated to use "main" instead of "dev". These changes ensure that the correct deploy key is used for SSH authentication during the deployment process and that the workflows and release configuration are aligned with the main branch.