### PR TITLE
chore: Update SSH deploy key in GitHub Actions workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -62,7 +62,8 @@ jobs:
       - name: Set up SSH
         uses: webfactory/ssh-agent@v0.5.3
         with:
-          ssh-private-key: ${{ secrets.KLINGON_TOOLS_DEPLOY_KEY }}
+          ssh-private-key: |
+            ${{ secrets.KLINGON_TOOLS_DEPLOY_KEY }}
 
       # Get PyPI Test Version Number
       - name: Get PyPI Test Version Number
@@ -164,7 +165,8 @@ jobs:
       - name: Set up SSH
         uses: webfactory/ssh-agent@v0.5.3
         with:
-          ssh-private-key: ${{ secrets.KLINGON_TOOLS_DEPLOY_KEY }}
+          ssh-private-key: |
+            ${{ secrets.KLINGON_TOOLS_DEPLOY_KEY }}
 
       # Echo the new version number
       - name: Echo the version number


### PR DESCRIPTION
The SSH deploy key used in the GitHub Actions workflow has been updated to use the `KLINGON_TOOLS_DEPLOY_KEY` secret instead of `SSH_DEPLOY_KEY`. This change ensures that the correct deploy key is used for SSH authentication during the deployment process.

Signed-off-by: David Hooton <david@hooton.org>