### PR TITLE
Fix code scanning alert no. 2: Flask app is run in debug mode

### DIFF
--- a/archive/Cxcel/main.py
+++ b/archive/Cxcel/main.py
@@ -7,6 +7,7 @@ import pandas as pd
 from flask import Flask, jsonify, render_template
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
+import os
 
 # Initialize Flask app
 app = Flask(__name__)
@@ -154,7 +155,8 @@ def update():
 
 
 def run_web_server():
-    app.run(debug=True, use_reloader=True)
+    debug_mode = os.getenv('FLASK_DEBUG', 'False').lower() in ['true', '1', 't']
+    app.run(debug=debug_mode, use_reloader=True)
 
 
 def main():
@@ -177,7 +179,8 @@ def main():
         observer.schedule(event_handler, path=filename, recursive=False)
         observer.start()
 
-        app.run(debug=True, use_reloader=True)
+        debug_mode = os.getenv('FLASK_DEBUG', 'False').lower() in ['true', '1', 't']
+        app.run(debug=debug_mode, use_reloader=True)
 
         try:
             while True:


### PR DESCRIPTION
Fixes [https://github.com/djh00t/klingon_tools/security/code-scanning/2](https://github.com/djh00t/klingon_tools/security/code-scanning/2)

To fix the problem, we need to ensure that the Flask application does not run in debug mode when deployed in a production environment. This can be achieved by using an environment variable to control the debug mode. We will modify the code to check the environment variable and set the debug mode accordingly.

1. Import the `os` module to access environment variables.
2. Modify the `app.run` calls to set the `debug` parameter based on the value of an environment variable (e.g., `FLASK_DEBUG`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
