### PR TITLE
Fix code scanning alert no. 1: Flask app is run in debug mode

### DIFF
--- a/archive/Cxcel/main.py
+++ b/archive/Cxcel/main.py
@@ -154,7 +154,9 @@ def update():
 
 
 def run_web_server():
-    app.run(debug=True, use_reloader=True)
+    import os
+    debug_mode = os.getenv('FLASK_DEBUG', 'false').lower() in ['true', '1', 't']
+    app.run(debug=debug_mode, use_reloader=True)
 
 
 def main():
@@ -177,7 +179,7 @@ def main():
         observer.schedule(event_handler, path=filename, recursive=False)
         observer.start()
 
-        app.run(debug=True, use_reloader=True)
+        run_web_server()
 
         try:
             while True:


### PR DESCRIPTION
Fixes [https://github.com/djh00t/klingon_tools/security/code-scanning/1](https://github.com/djh00t/klingon_tools/security/code-scanning/1)

To fix the problem, we need to ensure that the Flask application does not run in debug mode in a production environment. The best way to achieve this is to use an environment variable to control the debug mode. This way, we can easily switch between development and production settings without changing the code.

We will modify the `run_web_server` function and the `main` function to check for an environment variable that indicates whether the application is running in development mode. If the environment variable is set, we will enable debug mode; otherwise, we will disable it.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
